### PR TITLE
Needed to change the IGAUTO and BL to correct settings.

### DIFF
--- a/settings.cfg
+++ b/settings.cfg
@@ -29,7 +29,7 @@ UPTIME NA Read the total Power ON Hours since the last power cycle or RST comman
 VER NA Read FW version number               
 VTRAC NA Get the VacTrac statistics from the controller.         
 AO 1,1.0,1.0E-10,1.0,9.8,9.3 Get or set the analog output mode.         
-BL NA Set the gauge button lock or get the button lock state.     
+BL ON Set the gauge button lock or get the button lock state.     
 CC NA Get or set the calibration curve.          
 CCID NA Get or set the calibration curve ID string.        
 CFM NA Get or set the pressure correction factor multiplier.        
@@ -43,5 +43,5 @@ GTM NA Get or set the gas type multiplier.
 #HELP NA Get all the supported user commands.          
 #IG NA Get or set the cold cathode ion gauge ON or OFF.     
 IGAIN NA Get or set the cold cathode ion gauge configuration for Analog Input.    
-IGAUTO NA Get or set the cold cathode ion gauge auto ON/OFF configuration.     
+IGAUTO 1,DIN Get or set the cold cathode ion gauge auto ON/OFF configuration.     
 IGDIN LOW,0 Get or set the cold cathode ion gauge auto ON / OFF configuration for Digital Input.


### PR DESCRIPTION
IGAUTO - Needs to be 1,DIN to indicate the DIN should be use to auto-start the gauge.
BL - Button lock to prevent undoing the configuration (when the button is pressed it disables the auto-start settings, IGAUTO)